### PR TITLE
fix: ヘッダ部分が下にいった状態でスクリーンショットが撮られる不具合を修正

### DIFF
--- a/.github/gen-page-preview/main.spec.ts
+++ b/.github/gen-page-preview/main.spec.ts
@@ -62,6 +62,9 @@ test("page screenshot", async ({ page }) => {
     console.log("URL: " + url);
     await page.goto(url, { waitUntil: "networkidle" });
     await scrollFullPage(page);
+    await page.evaluate(() => {
+      window.scrollBy(0, -document.body.scrollHeight);
+    });
     await page.screenshot({
       path: "screenshots/" + file + ".png",
       fullPage: true,


### PR DESCRIPTION
![](https://camo.githubusercontent.com/be5d2e35565cb4a2f56fadb79d35ed56916e75b4cfdfed41f8d78c32d648dbbd/68747470733a2f2f692e696d6775722e636f6d2f594977697a44542e706e67)

すべてをスクロールして、ロードしてからスクリーンショットを撮る影響でヘッダーが下移動したままスクショが撮られてしまうので最後に一番上にスクロールを戻してからスクショを撮るようにしてみます