### PR TITLE
chore(generate-page-preview-image): downgrade nodejs

### DIFF
--- a/.github/workflows/generate-page-preview-image.yml
+++ b/.github/workflows/generate-page-preview-image.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 16
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
あげすぎてnuxtビルドできなくなった